### PR TITLE
Use data types when setting callbacks

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -501,7 +501,7 @@ extern "C" rmw_ret_t rmw_guard_condition_set_events_executor_callback(
   return RMW_RET_UNSUPPORTED;
 }
 
-extern "C" rmw_ret_t rmw_event_set_listener_callback(
+extern "C" rmw_ret_t rmw_event_set_events_executor_callback(
   const void * executor_context,
   EventsExecutorCallback callback,
   const void * waitable_handle,
@@ -518,7 +518,7 @@ extern "C" rmw_ret_t rmw_event_set_listener_callback(
   //                              waitable_handle, use_previous_events);
   RCUTILS_LOG_ERROR_NAMED(
     "rmw_node.cpp",
-    "rmw_event_set_listener_callback: not supported (yet)");
+    "rmw_event_set_events_executor_callback: not supported (yet)");
   return RMW_RET_UNSUPPORTED;
 }
 

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -428,15 +428,15 @@ extern "C" rmw_ret_t rmw_set_log_severity(rmw_log_severity_t severity)
 
 extern "C" rmw_ret_t rmw_subscription_set_events_executor_callback(
   const void * executor_context,
-  EventsExecutorCallback executor_callback,
+  EventsExecutorCallback callback,
   const void * subscription_handle,
-  void * rmw_subscription)
+  rmw_subscription_t * rmw_subscription)
 {
   (void)executor_context;
-  (void)executor_callback;
+  (void)callback;
   (void)subscription_handle;
   (void)rmw_subscription;
-  // auto subscription = static_cast<CddsSubscription *>(rmw_subscription);
+  // auto subscription = static_cast<CddsSubscription *>(rmw_subscription->data);
   // subscription->setCallback(executor_context, callback, subscription_handle);
   RCUTILS_LOG_ERROR_NAMED(
     "rmw_node.cpp",
@@ -446,15 +446,15 @@ extern "C" rmw_ret_t rmw_subscription_set_events_executor_callback(
 
 extern "C" rmw_ret_t rmw_service_set_events_executor_callback(
   const void * executor_context,
-  EventsExecutorCallback executor_callback,
+  EventsExecutorCallback callback,
   const void * service_handle,
-  void * rmw_service)
+  rmw_service_t * rmw_service)
 {
   (void)executor_context;
-  (void)executor_callback;
+  (void)callback;
   (void)service_handle;
   (void)rmw_service;
-  // auto service = static_cast<CddsService *>(rmw_service);
+  // auto service = static_cast<CddsService *>(rmw_service->data);
   // service->setCallback(executor_context, callback, service_handle);
   RCUTILS_LOG_ERROR_NAMED(
     "rmw_node.cpp",
@@ -464,15 +464,15 @@ extern "C" rmw_ret_t rmw_service_set_events_executor_callback(
 
 extern "C" rmw_ret_t rmw_client_set_events_executor_callback(
   const void * executor_context,
-  EventsExecutorCallback executor_callback,
+  EventsExecutorCallback callback,
   const void * client_handle,
-  void * rmw_client)
+  rmw_client_t * rmw_client)
 {
   (void)executor_context;
-  (void)executor_callback;
+  (void)callback;
   (void)client_handle;
   (void)rmw_client;
-  // auto client = static_cast<CddsClient *>(rmw_client);
+  // auto client = static_cast<CddsClient *>(rmw_client->data);
   // client->setCallback(executor_context, callback, client_handle);
   RCUTILS_LOG_ERROR_NAMED(
     "rmw_node.cpp",
@@ -482,17 +482,17 @@ extern "C" rmw_ret_t rmw_client_set_events_executor_callback(
 
 extern "C" rmw_ret_t rmw_guard_condition_set_events_executor_callback(
   const void * executor_context,
-  EventsExecutorCallback executor_callback,
+  EventsExecutorCallback callback,
   const void * guard_condition_handle,
-  void * rmw_guard_condition,
+  rmw_guard_condition_t * rmw_guard_condition,
   bool use_previous_events)
 {
   (void)executor_context;
-  (void)executor_callback;
+  (void)callback;
   (void)guard_condition_handle;
   (void)rmw_guard_condition;
   (void)use_previous_events;
-  // auto guard_condition = static_cast<CddsGuardCondition *>(rmw_guard_condition);
+  // auto guard_condition = static_cast<CddsGuardCondition *>(rmw_guard_condition->data);
   // guard_condition->setCallback(executor_context, callback,
   //                              guard_condition_handle, use_previous_events);
   RCUTILS_LOG_ERROR_NAMED(
@@ -501,6 +501,26 @@ extern "C" rmw_ret_t rmw_guard_condition_set_events_executor_callback(
   return RMW_RET_UNSUPPORTED;
 }
 
+extern "C" rmw_ret_t rmw_event_set_listener_callback(
+  const void * executor_context,
+  EventsExecutorCallback callback,
+  const void * waitable_handle,
+  rmw_event_t * rmw_event,
+  bool use_previous_events)
+{
+  (void)executor_context;
+  (void)callback;
+  (void)waitable_handle;
+  (void)rmw_event;
+  (void)use_previous_events;
+  // auto event = static_cast<CddsEvent *>(rmw_event->data);
+  // event->setCallback(executor_context, callback,
+  //                              waitable_handle, use_previous_events);
+  RCUTILS_LOG_ERROR_NAMED(
+    "rmw_node.cpp",
+    "rmw_event_set_listener_callback: not supported (yet)");
+  return RMW_RET_UNSUPPORTED;
+}
 
 extern "C" rmw_ret_t rmw_init_options_init(
   rmw_init_options_t * init_options,


### PR DESCRIPTION
Also add missing stub for `rmw_event_set_events_executor_callback`