### PR TITLE
Comment error message log statement in rmw_publisher_count_non_local_matched_subscriptions

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2746,7 +2746,7 @@ extern "C" rmw_ret_t rmw_publisher_count_non_local_matched_subscriptions(
 {
   static_cast<void>(publisher);
   static_cast<void>(non_local_subscription_count);
-  RMW_SET_ERROR_MSG("rmw_publisher_count_non_local_matched_subscriptions not implemented for rmw_cyclonedds_cpp");
+  //RMW_SET_ERROR_MSG("rmw_publisher_count_non_local_matched_subscriptions not implemented for rmw_cyclonedds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 


### PR DESCRIPTION
Comment-out the error message log statement from `rmw_publisher_count_non_local_matched_subscriptions`