### PR TITLE
Implement rmw_notify_participant_dynamic_network_interface as a stub

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1499,6 +1499,13 @@ extern "C" rmw_ret_t rmw_context_fini(rmw_context_t * context)
   return ret;
 }
 
+extern "C" rmw_ret_t rmw_notify_participant_dynamic_network_interface(rmw_context_t * context)
+{
+  static_cast<void>(context);
+  // RMW_SET_ERROR_MSG("rmw_notify_participant_dynamic_network_interface not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 ///////////                                                                   ///////////
 ///////////    NODES                                                          ///////////

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1502,7 +1502,7 @@ extern "C" rmw_ret_t rmw_context_fini(rmw_context_t * context)
 extern "C" rmw_ret_t rmw_notify_participant_dynamic_network_interface(rmw_context_t * context)
 {
   static_cast<void>(context);
-  // RMW_SET_ERROR_MSG("rmw_notify_participant_dynamic_network_interface not implemented for rmw_cyclonedds_cpp");
+  RMW_SET_ERROR_MSG("rmw_notify_participant_dynamic_network_interface not implemented for rmw_cyclonedds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 


### PR DESCRIPTION
On the Create3, under Humble, this error is observed:
```bash
'failed to resolve symbol 'rmw_notify_participant_dynamic_network_interface' \
    in shared library '/usr/lib/librmw_cyclonedds_cpp.so'
```
This PR adds it as a stub function, simply returning `RMW_RET_UNSUPPORTED`